### PR TITLE
add derived type for sis2 change

### DIFF
--- a/combined_ice_ocean_driver.F90
+++ b/combined_ice_ocean_driver.F90
@@ -38,6 +38,10 @@ type, public :: ice_ocean_driver_type ; private
   logical :: CS_is_initialized = .false.
 end type ice_ocean_driver_type
 
+!> dummy type to pass compilation
+type, public :: ocean_ice_boundary_type
+end type
+
 contains
 
 !>   This subroutine initializes the combined ice ocean coupling control type.


### PR DESCRIPTION
#5 added an argument to match up with the sis2 argument change but its type wasn't defined here yet so still led to compilation errors, this just adds a dummy type to get it working.

tested with the null coupler build